### PR TITLE
Fixing broken URIs in SPARQL queries

### DIFF
--- a/piano_and_trumpet_Db.rql
+++ b/piano_and_trumpet_Db.rql
@@ -1,16 +1,16 @@
 prefix mo: <http://purl.org/ontology/mo/>
 
-select ?performance ?name
+select distinct ?performance ?name
 where {
 
 ?performance a mo:Performance ;
-             mo:instrument <http://jazzcats.oerc.ox.ac.uk/instrument/piano> ;
+             mo:instrument <http://jazzcats.oerc.ox.ac.uk/data/instrument/piano> ;
              mo:produced_sound ?sound ;
              mo:performer ?person .
 
 ?person a foaf:Person;
         rdfs:label ?name ;
-        mo:primary_instrument <http://jazzcats.oerc.ox.ac.uk/instrument/trumpet> .
+        mo:primary_instrument <http://jazzcats.oerc.ox.ac.uk/data/instrument/trumpet> .
 
 ?sound a mo:Sound ;
        mo:key  "Db" ;

--- a/things_about_Lee_Abrams
+++ b/things_about_Lee_Abrams
@@ -1,4 +1,4 @@
 prefix foaf: <http://xmlns.com/foaf/0.1/>
 
-select distinct ?p ?o where {<http://jazzcats.oerc.ox.ac.uk/person/Lee_Abrams> ?p ?o }
+select distinct ?p ?o where {<http://jazzcats.oerc.ox.ac.uk/data/person/Lee_Abrams> ?p ?o }
 


### PR DESCRIPTION
This PRs fixes the broken URIs in two of the SPARQL query example files. Other files are working.